### PR TITLE
Make it possible to truncate files

### DIFF
--- a/config/options.go
+++ b/config/options.go
@@ -19,8 +19,9 @@ type OptionsType struct {
 
 	Printer string `short:"p" long:"printer" description:"the output printer to use (valid printers: ncurses, text, json)" default:"ncurses"`
 
-	Output       string `short:"o" long:"output" description:"the output channel to send printer output (valid output: stdout, file, tcp, udp)" default:"stdout"`
-	OutputTarget string `long:"target" description:"for output 'file' the location, for 'tcp' or 'udp' the url (host:port) to the server"`
+	Output                string `short:"o" long:"output" description:"the output channel to send printer output (valid output: stdout, file, tcp, udp)" default:"stdout"`
+	OutputTarget          string `long:"target" description:"for output 'file' the location, for 'tcp' or 'udp' the url (host:port) to the server"`
+	OutputTargetTruncate  bool `long:"targettruncate" description:"for output 'file' the target will only contain the latest result (can be used for prometheus json exporter)"`
 
 	NetworkDevice string `long:"netdev" description:"The network device used for the virtual traffic"`
 	StorageDevice string `long:"storedev" description:"The storage device used for the virtual block devices"`

--- a/runners/printer.go
+++ b/runners/printer.go
@@ -41,6 +41,14 @@ func InitializePrinter(wg *sync.WaitGroup) {
 
 // Print runs one printing cycle
 func Print() {
+        if config.Options.Output == "file" && config.Options.OutputTargetTruncate {
+                err := os.Truncate(config.Options.OutputTarget, 0)
+                if err != nil {
+                        fmt.Fprintf(os.Stderr, "failed to truncate the output file")
+                        os.Exit(1)
+                }
+        }
+
 	printable := models.Printable{}
 
 	// add general domain fields first

--- a/runners/printer.go
+++ b/runners/printer.go
@@ -41,13 +41,13 @@ func InitializePrinter(wg *sync.WaitGroup) {
 
 // Print runs one printing cycle
 func Print() {
-        if config.Options.Output == "file" && config.Options.OutputTargetTruncate {
-                err := os.Truncate(config.Options.OutputTarget, 0)
-                if err != nil {
-                        fmt.Fprintf(os.Stderr, "failed to truncate the output file")
-                        os.Exit(1)
-                }
-        }
+	if config.Options.Output == "file" && config.Options.OutputTargetTruncate {
+		err := os.Truncate(config.Options.OutputTarget, 0)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "failed to truncate the output file")
+			os.Exit(1)
+		}
+	}
 
 	printable := models.Printable{}
 


### PR DESCRIPTION
We want to have the kvmtop data in Prometheus and not the setup with Logstash and Influxdb. Therefor we need to have a json file which only has the latest results. 
With adding the parameter --targettruncate we can truncate the target file (only for the file option) on every run. This means we can use this json file with the json_exporter for Prometheus.